### PR TITLE
Disabled edges and nodes physics

### DIFF
--- a/src/gui_functions.js
+++ b/src/gui_functions.js
@@ -674,6 +674,9 @@ function showLateralMovement(){
 
         // Configuration for the Timeline
         var options = {
+            physics:{
+                enabled: false
+            },
             edges: {},
             nodes: {
                 font: {


### PR DESCRIPTION
I disabled the terrible edges and nodes physics on Lateral Movement view by setting to _false_ the _physics_ property on _options_ variable as documented [here](https://visjs.github.io/vis-network/docs/network/physics.html).