### PR TITLE
Fix CSV import header and empty row issue

### DIFF
--- a/src/helper_functions.js
+++ b/src/helper_functions.js
@@ -40,7 +40,7 @@ function CSVtoArray(text) {
 }
 
 function CSVtoArrayEasy(text){
-
+    if (!text) return;
     return text.split(",")
 
 }

--- a/src/import.js
+++ b/src/import.js
@@ -58,7 +58,7 @@ function import_data() {
     //when adding only add existing fields. so iun the add loop rather than going through the input data go through the mapping data and add only what's in there
 
     //build import data
-    for(var i=0;i<import_lines.length;i++){
+    for(var i=1;i<import_lines.length;i++){
         fields = CSVtoArrayEasy(import_lines[i])
        // console.log(fields)
         var import_object = {}


### PR DESCRIPTION
Hi there,

I found a bug in the current implementation of the CSV import feature. The header of the CSV file is being imported into a table row, and there is also an extra table row with an empty value.

![image](https://user-images.githubusercontent.com/21971925/235944010-28b43e6c-2d0b-4914-9ff5-8bfd08d2d13a.png)

I have modified the import code
![image](https://user-images.githubusercontent.com/21971925/235944294-81ce0875-39af-48eb-95a2-692cd17dfe24.png)

Please review my changes and let me know if there is anything else I can do to help.

Thank you for considering my pull request!
